### PR TITLE
Windows: shell out to tzinfo in a way that's safe for Go 1.18 and lower

### DIFF
--- a/tzlocal/tz_windows.go
+++ b/tzlocal/tz_windows.go
@@ -4,7 +4,6 @@ package tzlocal
 
 import (
 	"fmt"
-	"os/exec"
 	"strings"
 
 	"golang.org/x/sys/windows/registry"
@@ -31,16 +30,6 @@ func LocalTZ() (string, error) {
 		return name, nil
 	}
 	return "", fmt.Errorf("could not find IANA tz name for set time zone \"%s\"", winTZname)
-}
-
-// localTZfromTzutil executes command `tzutil /g` to get the name of the time zone Windows is configured to use.
-func localTZfromTzutil() (string, error) {
-	cmd := exec.Command("tzutil", "/g")
-	data, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(data)), nil
 }
 
 // localTZfromReg obtains the time zone Windows is configured to use from registry.

--- a/tzlocal/tz_windows_tzutil.go
+++ b/tzlocal/tz_windows_tzutil.go
@@ -1,0 +1,19 @@
+//go:build windows && go1.19
+// +build windows,go1.19
+
+package tzlocal
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// localTZfromTzutil executes command `tzutil /g` to get the name of the time zone Windows is configured to use.
+func localTZfromTzutil() (string, error) {
+	cmd := exec.Command("tzutil", "/g")
+	data, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}

--- a/tzlocal/tz_windows_tzutil_go1.18.go
+++ b/tzlocal/tz_windows_tzutil_go1.18.go
@@ -1,0 +1,20 @@
+//go:build windows && !go1.19
+// +build windows,!go1.19
+
+package tzlocal
+
+import (
+	"strings"
+
+	"golang.org/x/sys/execabs"
+)
+
+// localTZfromTzutil executes command `tzutil /g` to get the name of the time zone Windows is configured to use.
+func localTZfromTzutil() (string, error) {
+	cmd := execabs.Command("tzutil", "/g")
+	data, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(data)), nil
+}


### PR DESCRIPTION
Until Go 1.19, the `os/exec` package from standard library had a behavior of implicitly including the current directory when looking up commands to execute.

That means that for every Windows Go 1.18 (and lower) program that imports and invokes this library, Go could execute a malicious `./tzinfo.exe` from the current working directory.

Go 1.19 fixes this beavior, but Go 1.18 and older are vulnerable. This fix makes it so that Go 1.18 and older versions use the `execabs` package that is designed to patch the security risk.