### PR TITLE
Some UNIX local timezones aren't recognized

### DIFF
--- a/tzlocal/tz_unix_test.go
+++ b/tzlocal/tz_unix_test.go
@@ -3,15 +3,57 @@
 
 package tzlocal
 
-import "testing"
+import (
+	"testing"
+	"time"
+)
 
-func TestInferFromPathSuccess(t *testing.T) {
-	tz, err := inferFromPath("/usr/share/zoneinfo/Asia/Tokyo")
-	if err != nil {
-		t.Errorf("got err=%d; want: nil", err)
+func Test_inferFromPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		file    string
+		wantErr bool
+	}{
+		{
+			name:    "Asia/Tokyo",
+			file:    "/usr/share/zoneinfo/Asia/Tokyo",
+			wantErr: false,
+		},
+		{
+			name:    "America/Chicago",
+			file:    "/usr/share/zoneinfo/America/Chicago",
+			wantErr: false,
+		},
+		{
+			name:    "America/Kentucky/Monticello",
+			file:    "/usr/share/zoneinfo/America/Kentucky/Monticello",
+			wantErr: false,
+		},
+		{
+			name:    "America/Argentina/Buenos_Aires",
+			file:    "/usr/share/zoneinfo/America/Argentina/Buenos_Aires",
+			wantErr: false,
+		},
+		{
+			name:    "UTC",
+			file:    "/usr/share/zoneinfo/UTC",
+			wantErr: false,
+		},
 	}
-	want := "Asia/Tokyo"
-	if tz != want {
-		t.Errorf("got tz=%s; want: %s", tz, want)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := inferFromPath(tt.file)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("inferFromPath() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.name {
+				t.Errorf("inferFromPath() = %v, want %v", got, tt.name)
+			}
+			_, err = time.LoadLocation(tt.name)
+			if err != nil {
+				t.Errorf("can't load timezone %s: %s", tt.name, err.Error())
+			}
+		})
 	}
 }


### PR DESCRIPTION
The function  inferFromPath splits the file path of the current local time and takes the parts N-2 and N of the path as the time zone.


This can't work with following time zones:

- UTC
- America/Agentina/Buenos_Aires

Fixes #6
Add tests