### PR TITLE
Support zoneinfo.default location on macOS when using filepath.EvalSymlinks

### DIFF
--- a/tzlocal/tz_unix.go
+++ b/tzlocal/tz_unix.go
@@ -18,7 +18,7 @@ func inferFromPath(p string) (string, error) {
 
 	parts := strings.Split(p, string(filepath.Separator))
 	for i := range parts {
-		if parts[i] == "zoneinfo" {
+		if parts[i] == "zoneinfo" || parts[i] == "zoneinfo.default" {
 			parts = parts[i+1:]
 			break
 		}

--- a/tzlocal/tz_unix_test.go
+++ b/tzlocal/tz_unix_test.go
@@ -39,6 +39,16 @@ func Test_inferFromPath(t *testing.T) {
 			file:    "/usr/share/zoneinfo/UTC",
 			wantErr: false,
 		},
+		{ // MacOS - /var/db location
+			name:    "Europe/Berlin",
+			file:    "/var/db/timezone/zoneinfo/Europe/Berlin",
+			wantErr: false,
+		},
+		{ // MacOS - Final symlink target for /usr/share/zoneinfo and /var/db/timezone/zoneinfo
+			name:    "Europe/Berlin",
+			file:    "/usr/share/zoneinfo.default/Europe/Berlin",
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Description

[immich-go](https://github.com/simulot/immich-go) relies on this library to determine the current time zone. The latest release candidate, created after this change was introduced, is failing on my macOS Sequoia 15.0.

The symlink resolution method was updated to use `filepath.EvalSymlinks` in #12. On macOS, fully resolving the `/etc/localtime` symlink results in a path like `/usr/share/zoneinfo.default/...`, which is not currently supported by `inferFromPath`.

This PR updates `inferFromPath` to handle these cases by splitting paths on both `zoneinfo` and `zoneinfo.default`.

## Immich error output

```
unknown time zone usr/share/zoneinfo.default/Europe/Berlin
```

## readlink output

```
❯ readlink /usr/share/zoneinfo/
/usr/share/zoneinfo.default

❯ readlink /var/db/timezone/zoneinfo
/usr/share/zoneinfo.default
```