### PR TITLE
fix: set CREATE_NO_WINDOW on tzutil exec to prevent console flash

### DIFF
--- a/tzlocal/tz_windows_tzutil.go
+++ b/tzlocal/tz_windows_tzutil.go
@@ -6,11 +6,17 @@ package tzlocal
 import (
 	"os/exec"
 	"strings"
+	"syscall"
+
+	"golang.org/x/sys/windows"
 )
 
 // localTZfromTzutil executes command `tzutil /g` to get the name of the time zone Windows is configured to use.
 func localTZfromTzutil() (string, error) {
 	cmd := exec.Command("tzutil", "/g")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NO_WINDOW,
+	}
 	data, err := cmd.Output()
 	if err != nil {
 		return "", err

--- a/tzlocal/tz_windows_tzutil_go1.18.go
+++ b/tzlocal/tz_windows_tzutil_go1.18.go
@@ -5,13 +5,18 @@ package tzlocal
 
 import (
 	"strings"
+	"syscall"
 
 	"golang.org/x/sys/execabs"
+	"golang.org/x/sys/windows"
 )
 
 // localTZfromTzutil executes command `tzutil /g` to get the name of the time zone Windows is configured to use.
 func localTZfromTzutil() (string, error) {
 	cmd := execabs.Command("tzutil", "/g")
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CreationFlags: windows.CREATE_NO_WINDOW,
+	}
 	data, err := cmd.Output()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Description

Fixes https://github.com/thlib/go-timezone-local/issues/16

No worries if you just want to close it, but I thought I'd just open a PR to demonstrate the proposed fix. Cheers.